### PR TITLE
feat: Implement admin registration and frontend display for core models

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,0 +1,4 @@
+from django.contrib import admin
+from .models import UserProfile
+
+admin.site.register(UserProfile)

--- a/careers/admin.py
+++ b/careers/admin.py
@@ -1,0 +1,27 @@
+from django.contrib import admin
+from .models import Skill, Career
+
+# Unregister the models if they were previously registered simply
+# (This might not be strictly necessary if the overwrite_file_with_block replaces all content,
+# but it's good practice if we were appending or selectively modifying)
+# However, since we are overwriting, these unregister calls are not strictly needed here.
+# try:
+#     admin.site.unregister(Skill)
+# except admin.sites.NotRegistered:
+#     pass
+# try:
+#     admin.site.unregister(Career)
+# except admin.sites.NotRegistered:
+#     pass
+
+class SkillAdmin(admin.ModelAdmin):
+    list_display = ('name', 'description')
+    search_fields = ('name',)
+
+class CareerAdmin(admin.ModelAdmin):
+    list_display = ('name', 'description')
+    search_fields = ('name',)
+    filter_horizontal = ('required_skills',) # Use filter_horizontal for ManyToManyField
+
+admin.site.register(Skill, SkillAdmin)
+admin.site.register(Career, CareerAdmin)

--- a/careers/urls.py
+++ b/careers/urls.py
@@ -1,4 +1,9 @@
 from django.urls import path
+from . import views
+
+app_name = 'careers'
 
 urlpatterns = [
+    path('', views.career_list, name='career_list'),
+    path('<int:career_id>/', views.career_detail, name='career_detail'),
 ]

--- a/careers/views.py
+++ b/careers/views.py
@@ -1,0 +1,11 @@
+from django.shortcuts import render, get_object_or_404
+from .models import Career
+
+def career_list(request):
+    careers = Career.objects.all()
+    return render(request, 'careers/career_list.html', {'careers': careers})
+
+def career_detail(request, career_id):
+    career = get_object_or_404(Career, pk=career_id)
+    # Required skills can be accessed in the template via career.required_skills.all
+    return render(request, 'careers/career_detail.html', {'career': career})

--- a/learning_paths/admin.py
+++ b/learning_paths/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from .models import LearningResource, LearningPath, LearningPathStep
+
+admin.site.register(LearningResource)
+admin.site.register(LearningPath)
+admin.site.register(LearningPathStep)

--- a/learning_paths/urls.py
+++ b/learning_paths/urls.py
@@ -1,4 +1,8 @@
 from django.urls import path
+from . import views
+
+app_name = 'learning_paths'
 
 urlpatterns = [
+    path('career/<int:career_id>/', views.learning_path_detail, name='learning_path_for_career'),
 ]

--- a/learning_paths/views.py
+++ b/learning_paths/views.py
@@ -1,0 +1,17 @@
+from django.shortcuts import render, get_object_or_404
+from .models import LearningPath, LearningPathStep, LearningResource
+from careers.models import Career
+
+def learning_path_detail(request, career_id):
+    career = get_object_or_404(Career, pk=career_id)
+    learning_path = LearningPath.objects.filter(career=career).first()
+    steps = []
+    if learning_path:
+        steps = learning_path.steps.all().prefetch_related('resources')
+    
+    context = {
+        'career': career,
+        'learning_path': learning_path,
+        'steps': steps
+    }
+    return render(request, 'learning_paths/path_detail.html', context)

--- a/templates/careers/career_detail.html
+++ b/templates/careers/career_detail.html
@@ -1,118 +1,55 @@
 {% extends 'base.html' %}
+{% load static %}
 
-{% block title %}{{ career.name }} | Skill Path Recommender{% endblock %}
+{% block title %}{{ career.name }} | Career Details{% endblock %}
 
 {% block content %}
-<div class="row mb-4">
-    <div class="col-12">
-        <nav aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="{% url 'careers_list' %}">Careers</a></li>
-                <li class="breadcrumb-item active" aria-current="page">{{ career.name }}</li>
-            </ol>
-        </nav>
-    </div>
-</div>
+<div class="container mt-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+            <li class="breadcrumb-item"><a href="{% url 'careers:career_list' %}">Careers</a></li>
+            <li class="breadcrumb-item active" aria-current="page">{{ career.name }}</li>
+        </ol>
+    </nav>
 
-<div class="row mb-5">
-    <div class="col-lg-8">
-        <h1 class="mb-3">{{ career.name }}</h1>
-        
-        <div class="mb-4">
-            <span class="badge {% if career.difficulty_level == 1 %}bg-success{% elif career.difficulty_level == 2 %}bg-warning{% else %}bg-danger{% endif %} me-2">
-                {{ career.get_difficulty_level_display }}
-            </span>
-            <span class="badge bg-info me-2">{{ career.avg_completion_time }} weeks</span>
-        </div>
-        
-        <div class="mb-4">
-            <h3>Description</h3>
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h1 class="card-title display-4">{{ career.name }}</h1>
+            <hr>
             <p class="lead">{{ career.description }}</p>
-        </div>
-        
-        <h3 class="mb-3">Required Skills</h3>
-        <div class="row mb-4">
-            {% for skill in required_skills %}
-            <div class="col-md-6 mb-3">
-                <div class="card">
-                    <div class="card-body">
-                        <h5 class="card-title">{{ skill.name }}</h5>
-                        <div class="d-flex align-items-center mb-2">
-                            <div class="me-2">Proficiency Level:</div>
-                            <div class="progress flex-grow-1" style="height: 10px;">
-                                <div class="progress-bar {% if skill.level == 1 %}bg-success{% elif skill.level == 2 %}bg-warning{% else %}bg-danger{% endif %}" 
-                                     role="progressbar" 
-                                     style="width: {{ skill.level|floatformat:0|mult:33.33 }}%" 
-                                     aria-valuenow="{{ skill.level }}" 
-                                     aria-valuemin="0" 
-                                     aria-valuemax="3">
-                                </div>
-                            </div>
-                            <div class="ms-2">{{ skill.level_display }}</div>
-                        </div>
-                    </div>
+
+            <h3 class="mt-4">Required Skills:</h3>
+            {% if career.required_skills.all %}
+                <ul class="list-group list-group-flush">
+                    {% for skill in career.required_skills.all %}
+                        <li class="list-group-item">
+                            <strong>{{ skill.name }}</strong>
+                            {% if skill.description %}
+                                <p class="mb-0 text-muted">{{ skill.description|truncatewords:20 }}</p>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <div class="alert alert-secondary" role="alert">
+                    <p class="mb-0">No specific skills listed for this career yet. Explore general skills or check back later!</p>
                 </div>
-            </div>
-            {% empty %}
-            <div class="col-12">
-                <div class="alert alert-info">No specific skills listed for this career.</div>
-            </div>
-            {% endfor %}
-        </div>
-    </div>
-    
-    <div class="col-lg-4">
-        <div class="card mb-4 sticky-top" style="top: 20px;">
-            <div class="card-body">
-                <h4 class="card-title">Create Learning Path</h4>
-                <p>Get a personalized learning path for becoming a {{ career.name }}.</p>
-                
-                {% if user.is_authenticated %}
-                <form method="post" action="{% url 'career_selection' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="career_id" value="{{ career.id }}">
-                    <button type="submit" class="btn btn-primary btn-lg w-100">
-                        <i class="fas fa-map-marked-alt me-2"></i> Create My Path
-                    </button>
-                </form>
-                {% else %}
-                <div class="alert alert-info">
-                    <i class="fas fa-info-circle me-2"></i> You need to be logged in to create a personalized learning path.
-                </div>
-                <a href="{% url 'login' %}?next={% url 'career_detail' career_id=career.id %}" class="btn btn-primary w-100 mb-2">
-                    Login
+            {% endif %}
+            
+            <div class="mt-4">
+                <a href="{% url 'careers:career_list' %}" class="btn btn-outline-primary">
+                    <i class="fas fa-arrow-left"></i> Back to Career List
                 </a>
-                <a href="{% url 'signup' %}" class="btn btn-outline-primary w-100">
-                    Sign Up
+                <a href="{% url 'learning_paths:learning_path_for_career' career.id %}" class="btn btn-info ms-2">
+                    <i class="fas fa-route"></i> View Learning Path
                 </a>
-                {% endif %}
-            </div>
-        </div>
-        
-        <div class="card">
-            <div class="card-body">
-                <h4 class="card-title">Average Completion</h4>
-                <p>Based on typical learning pace:</p>
-                
-                <div class="d-flex align-items-center mb-3">
-                    <div class="me-3">
-                        <i class="fas fa-calendar-alt fa-2x text-primary"></i>
-                    </div>
-                    <div>
-                        <h5 class="mb-0">{{ career.avg_completion_time }} weeks</h5>
-                        <p class="text-muted mb-0">Full-time study</p>
-                    </div>
-                </div>
-                
-                <div class="d-flex align-items-center">
-                    <div class="me-3">
-                        <i class="fas fa-business-time fa-2x text-primary"></i>
-                    </div>
-                    <div>
-                        <h5 class="mb-0">{{ career.avg_completion_time|mult:2 }} weeks</h5>
-                        <p class="text-muted mb-0">Part-time study</p>
-                    </div>
-                </div>
+                {# Placeholder for future "Start Learning Path for this Career" button #}
+                {# {% if user.is_authenticated %}
+                <a href="#" class="btn btn-success">
+                    <i class="fas fa-play-circle"></i> Start Learning Path
+                </a>
+                {% endif %} #}
             </div>
         </div>
     </div>

--- a/templates/careers/career_list.html
+++ b/templates/careers/career_list.html
@@ -1,96 +1,32 @@
 {% extends 'base.html' %}
+{% load static %}
 
-{% block title %}Careers | Skill Path Recommender{% endblock %}
+{% block title %}Available Careers | Skill Path Recommender{% endblock %}
 
 {% block content %}
-<div class="row mb-4">
-    <div class="col-12">
-        <h1>Explore Careers</h1>
-        <p class="lead">Browse through different career paths and find the perfect match for your goals</p>
-    </div>
-</div>
+<div class="container mt-4">
+    <h1>Available Careers</h1>
+    <hr>
 
-<div class="row mb-4">
-    <div class="col-md-8">
-        <div class="input-group mb-3">
-            <input type="text" id="careerSearch" class="form-control" placeholder="Search careers...">
-            <button class="btn btn-outline-primary" type="button">
-                <i class="fas fa-search"></i> Search
-            </button>
-        </div>
-    </div>
-    <div class="col-md-4 text-md-end">
-        {% if user.is_authenticated %}
-        <a href="{% url 'generate_path' %}" class="btn btn-primary">
-            <i class="fas fa-plus-circle"></i> Create Learning Path
-        </a>
-        {% else %}
-        <a href="{% url 'login' %}" class="btn btn-primary">
-            <i class="fas fa-sign-in-alt"></i> Login to Create Path
-        </a>
-        {% endif %}
-    </div>
-</div>
-
-<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 career-cards">
-    {% for career in careers %}
-    <div class="col">
-        <div class="card h-100 career-card">
-            <div class="card-body">
-                <h3 class="card-title">{{ career.name }}</h3>
-                <div class="mb-3">
-                    <span class="badge {% if career.difficulty_level == 1 %}bg-success{% elif career.difficulty_level == 2 %}bg-warning{% else %}bg-danger{% endif %}">
-                        {{ career.get_difficulty_level_display }}
-                    </span>
-                    <span class="badge bg-info">{{ career.avg_completion_time }} weeks</span>
+    {% if careers %}
+        <div class="list-group">
+            {% for career in careers %}
+            <div class="list-group-item list-group-item-action flex-column align-items-start mb-3 shadow-sm">
+                <div class="d-flex w-100 justify-content-between">
+                    <h2 class="mb-1"><a href="{% url 'careers:career_detail' career.id %}">{{ career.name }}</a></h2>
                 </div>
-                <p class="card-text">{{ career.description|truncatechars:150 }}</p>
-                <div class="d-flex justify-content-between align-items-center mt-3">
-                    <a href="{% url 'career_detail' career_id=career.id %}" class="btn btn-outline-primary">Learn More</a>
-                    {% if user.is_authenticated %}
-                    <form method="post" action="{% url 'career_selection' %}">
-                        {% csrf_token %}
-                        <input type="hidden" name="career_id" value="{{ career.id }}">
-                        <button type="submit" class="btn btn-primary">
-                            <i class="fas fa-map-marker-alt"></i> Create Path
-                        </button>
-                    </form>
-                    {% endif %}
-                </div>
+                <p class="mb-1">{{ career.description|truncatewords:30 }}</p>
             </div>
+            {% empty %}
+            <div class="alert alert-info" role="alert">
+                <p class="mb-0">No careers available at the moment. Please check back later!</p>
+            </div>
+            {% endfor %}
         </div>
-    </div>
-    {% empty %}
-    <div class="col-12">
-        <div class="alert alert-info">
-            No careers found. Check back later for more options.
+    {% else %}
+        <div class="alert alert-info" role="alert">
+            <p class="mb-0">No careers available at the moment. Please check back later!</p>
         </div>
-    </div>
-    {% endfor %}
+    {% endif %}
 </div>
-
-{% endblock %}
-
-{% block extra_js %}
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const searchInput = document.getElementById('careerSearch');
-        const careerCards = document.querySelectorAll('.career-card');
-        
-        searchInput.addEventListener('input', function() {
-            const searchTerm = this.value.toLowerCase();
-            
-            careerCards.forEach(function(card) {
-                const title = card.querySelector('.card-title').textContent.toLowerCase();
-                const description = card.querySelector('.card-text').textContent.toLowerCase();
-                
-                if (title.includes(searchTerm) || description.includes(searchTerm)) {
-                    card.parentElement.style.display = '';
-                } else {
-                    card.parentElement.style.display = 'none';
-                }
-            });
-        });
-    });
-</script>
 {% endblock %}

--- a/templates/learning_paths/path_detail.html
+++ b/templates/learning_paths/path_detail.html
@@ -1,221 +1,61 @@
 {% extends 'base.html' %}
+{% load static %}
 
-{% block title %}{{ path.name }} | Skill Path Recommender{% endblock %}
+{% block title %}Learning Path for {{ career.name }}{% endblock %}
 
 {% block content %}
-<div class="row mb-4">
-    <div class="col-12">
-        <nav aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="{% url 'learning_path_list' %}">Learning Paths</a></li>
-                <li class="breadcrumb-item active" aria-current="page">{{ path.name }}</li>
-            </ol>
-        </nav>
-    </div>
-</div>
+<div class="container mt-4">
+    <h1>Learning Path for {{ career.name }}</h1>
+    <hr>
 
-<div class="row mb-4">
-    <div class="col-lg-8">
-        <h1 class="mb-2">{{ path.name }}</h1>
-        <p class="mb-3 text-muted">Career: {{ path.career.name }}</p>
-        
-        <div class="mb-4">
-            <span class="badge {% if path.difficulty_level == 1 %}bg-success{% elif path.difficulty_level == 2 %}bg-warning{% else %}bg-danger{% endif %} me-2">
-                {{ path.get_difficulty_level_display }}
-            </span>
-            <span class="badge bg-secondary me-2">
-                {{ steps|length }} Steps
-            </span>
-            {% if progress %}
-            <span class="badge bg-info">
-                {{ progress.get_completion_percentage|floatformat:0 }}% Complete
-            </span>
-            {% endif %}
-        </div>
-        
-        <p class="lead">{{ path.description }}</p>
-    </div>
-    
-    <div class="col-lg-4">
-        {% if progress %}
-        <div class="card mb-4">
-            <div class="card-body">
-                <h4 class="card-title">Your Progress</h4>
-                <div class="d-flex justify-content-between align-items-center mb-2">
-                    <span>Completion</span>
-                    <span class="fw-bold">{{ progress.get_completion_percentage|floatformat:0 }}%</span>
-                </div>
-                <div class="progress mb-3">
-                    <div class="progress-bar bg-success" 
-                         role="progressbar" 
-                         style="width: {{ progress.get_completion_percentage }}%" 
-                         aria-valuenow="{{ progress.get_completion_percentage }}" 
-                         aria-valuemin="0" 
-                         aria-valuemax="100"></div>
-                </div>
-                
-                <div class="d-flex justify-content-between align-items-center">
-                    <span>Steps Completed</span>
-                    <span class="fw-bold">{{ progress.completed_steps|length }} / {{ steps|length }}</span>
-                </div>
-                
-                <div class="mt-3">
-                    <small class="text-muted">Last activity: {{ progress.last_activity|date:"M d, Y" }}</small>
-                </div>
-            </div>
-        </div>
+    {% if learning_path %}
+        <h2>{{ learning_path.title }}</h2>
+        {% if learning_path.description %}
+            <p class="lead">{{ learning_path.description }}</p>
         {% endif %}
         
-        <div class="card">
-            <div class="card-body">
-                <h4 class="card-title">Path Information</h4>
-                <ul class="list-group list-group-flush">
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <span>Difficulty</span>
-                        <span>{{ path.get_difficulty_level_display }}</span>
-                    </li>
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <span>Created</span>
-                        <span>{{ path.created_at|date:"M d, Y" }}</span>
-                    </li>
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <span>Updated</span>
-                        <span>{{ path.updated_at|date:"M d, Y" }}</span>
-                    </li>
-                </ul>
-                
-                {% if user.is_authenticated and user == path.user %}
-                <div class="mt-3">
-                    <a href="{% url 'generate_path' %}" class="btn btn-outline-primary btn-sm w-100">
-                        <i class="fas fa-sync-alt me-2"></i> Regenerate Path
-                    </a>
-                </div>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-</div>
-
-<div class="row">
-    <div class="col-12">
-        <h2 class="mb-4">Learning Steps</h2>
-        
-        <div class="path-timeline">
-            {% for step in steps %}
-            {% with is_completed=False %}
-                {% if progress %}
-                    {% with is_completed=step.id|stringformat:"i" in progress.completed_steps %}
-                    <div class="step {% if is_completed %}completed{% endif %}">
-                        <div class="step-marker">
-                            {% if is_completed %}
-                            <i class="fas fa-check"></i>
-                            {% else %}
-                            {{ forloop.counter }}
-                            {% endif %}
-                        </div>
-                        <div class="card mb-4 {% if is_completed %}border-success{% endif %}">
-                            <div class="card-header d-flex justify-content-between align-items-center {% if is_completed %}bg-success text-white{% endif %}">
-                                <h5 class="mb-0">Step {{ forloop.counter }}: {{ step.title }}</h5>
-                                {% if is_completed %}
-                                <span class="badge bg-light text-success">Completed</span>
-                                {% endif %}
-                            </div>
-                            <div class="card-body">
-                                <p>{{ step.description }}</p>
-                                
-                                <h6 class="mb-2">Skills:</h6>
-                                <div class="mb-3">
-                                    {% for skill in step.skills.all %}
-                                    <span class="badge bg-primary me-1">{{ skill.name }}</span>
-                                    {% empty %}
-                                    <em>No specific skills listed</em>
-                                    {% endfor %}
-                                </div>
-                                
-                                <h6 class="mb-2">Learning Resources:</h6>
-                                <ul class="list-group list-group-flush mb-3">
-                                    {% for resource in step.resources.all %}
-                                    <li class="list-group-item">
-                                        <div class="d-flex justify-content-between align-items-center">
-                                            <div>
-                                                <strong>{{ resource.title }}</strong>
-                                                <span class="badge {% if resource.is_free %}bg-success{% else %}bg-warning{% endif %} me-1">
-                                                    {% if resource.is_free %}Free{% else %}Paid{% endif %}
-                                                </span>
-                                                <span class="badge bg-secondary">{{ resource.get_resource_type_display }}</span>
-                                            </div>
-                                            <a href="{{ resource.url }}" target="_blank" class="btn btn-sm btn-outline-primary">
-                                                <i class="fas fa-external-link-alt"></i> Open
-                                            </a>
-                                        </div>
-                                    </li>
-                                    {% empty %}
-                                    <li class="list-group-item">No resources available for this step</li>
-                                    {% endfor %}
-                                </ul>
-                                
-                                <a href="{% url 'path_step_detail' path_id=path.id step_id=step.id %}" class="btn btn-primary">
-                                    View Step Details
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    {% endwith %}
-                {% else %}
-                <div class="step">
-                    <div class="step-marker">{{ forloop.counter }}</div>
-                    <div class="card mb-4">
-                        <div class="card-header">
-                            <h5 class="mb-0">Step {{ forloop.counter }}: {{ step.title }}</h5>
-                        </div>
-                        <div class="card-body">
-                            <p>{{ step.description }}</p>
-                            
-                            <h6 class="mb-2">Skills:</h6>
-                            <div class="mb-3">
-                                {% for skill in step.skills.all %}
-                                <span class="badge bg-primary me-1">{{ skill.name }}</span>
-                                {% empty %}
-                                <em>No specific skills listed</em>
-                                {% endfor %}
-                            </div>
-                            
-                            <h6 class="mb-2">Learning Resources:</h6>
-                            <ul class="list-group list-group-flush mb-3">
+        <h3 class="mt-4">Steps:</h3>
+        {% if steps %}
+            <ol class="list-group list-group-numbered">
+                {% for step in steps %}
+                <li class="list-group-item d-flex justify-content-between align-items-start flex-column">
+                    <div class="ms-2 me-auto">
+                        <h4 class="fw-bold">{{ step.title }} (Order: {{ step.order }})</h4>
+                        <p>{{ step.description }}</p>
+                        {% if step.resources.all %}
+                            <h5>Resources:</h5>
+                            <ul class="list-unstyled">
                                 {% for resource in step.resources.all %}
-                                <li class="list-group-item">
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <strong>{{ resource.title }}</strong>
-                                            <span class="badge {% if resource.is_free %}bg-success{% else %}bg-warning{% endif %} me-1">
-                                                {% if resource.is_free %}Free{% else %}Paid{% endif %}
-                                            </span>
-                                            <span class="badge bg-secondary">{{ resource.get_resource_type_display }}</span>
-                                        </div>
-                                        <a href="{{ resource.url }}" target="_blank" class="btn btn-sm btn-outline-primary">
-                                            <i class="fas fa-external-link-alt"></i> Open
-                                        </a>
-                                    </div>
+                                <li>
+                                    <a href="{{ resource.url }}" target="_blank" rel="noopener noreferrer">{{ resource.title }}</a> ({{ resource.get_resource_type_display }})
+                                    {% if resource.estimated_hours %}
+                                        <span class="badge bg-secondary rounded-pill">{{ resource.estimated_hours }} hrs</span>
+                                    {% endif %}
                                 </li>
-                                {% empty %}
-                                <li class="list-group-item">No resources available for this step</li>
                                 {% endfor %}
                             </ul>
-                            
-                            <a href="{% url 'path_step_detail' path_id=path.id step_id=step.id %}" class="btn btn-primary">
-                                View Step Details
-                            </a>
-                        </div>
+                        {% else %}
+                            <p class="text-muted">No specific resources for this step.</p>
+                        {% endif %}
                     </div>
-                </div>
-                {% endif %}
-            {% endwith %}
-            {% empty %}
-            <div class="alert alert-info">
-                <p>No steps have been defined for this learning path yet.</p>
+                </li>
+                {% endfor %}
+            </ol>
+        {% else %}
+            <div class="alert alert-info" role="alert">
+                <p class="mb-0">No steps defined for this learning path yet.</p>
             </div>
-            {% endfor %}
+        {% endif %}
+    {% else %}
+        <div class="alert alert-warning" role="alert">
+            <p class="mb-0">No learning path available for {{ career.name }} at the moment. Please check back later or consider contributing one!</p>
         </div>
+    {% endif %}
+
+    <div class="mt-4">
+        <a href="{% url 'careers:career_detail' career.id %}" class="btn btn-outline-primary">
+            <i class="fas fa-arrow-left"></i> Back to {{ career.name }} details
+        </a>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This commit includes:

- Registration of UserProfile, Skill, Career, LearningResource, LearningPath, and LearningPathStep models in their respective app's admin.py files.
- Enhanced admin interface for Career and Skill models using ModelAdmin for better usability (e.g., filter_horizontal for Career's required_skills).
- Implementation of basic frontend views, URLs, and templates for:
  - Listing all careers (careers/career_list.html).
  - Displaying detailed information for a single career, including its required skills (careers/career_detail.html).
  - Displaying an initial, simplified learning path for a chosen career, including ordered steps and associated resources (learning_paths/path_detail.html).
- Added a navigation link from the career detail page to its associated learning path page.

These changes allow for data management via the admin panel and provide initial user-facing views for careers and their learning paths.